### PR TITLE
Fix scroll sync null container error

### DIFF
--- a/contexts/scroll-sync-context.tsx
+++ b/contexts/scroll-sync-context.tsx
@@ -249,6 +249,8 @@ export function useChatScrollDetection() {
         if (now !== lastScrollTimeRef.current) return
 
         const container = e.currentTarget
+        if (!container) return
+
         const messageElements = container.querySelectorAll('[data-message-id]')
 
         if (messageElements.length === 0) return


### PR DESCRIPTION
## Summary
- ✅ Fixed runtime TypeError in scroll detection handler
- ✅ Added null check for `e.currentTarget` before calling `querySelectorAll`
- ✅ Prevents "can't access property 'querySelectorAll', container is null" error

## Problem
The `useChatScrollDetection` hook was throwing a runtime error when `e.currentTarget` was null, causing the scroll synchronization feature to crash.

## Solution
Added an early return guard clause to check if `container` is null before attempting to call `querySelectorAll` on it.

## Test Plan
- [x] Verify scroll detection works without throwing errors
- [x] Confirm scroll synchronization between chat and analysis panels still functions
- [x] Test edge cases where scroll events might have null currentTarget

🤖 Generated with [Claude Code](https://claude.ai/code)