### PR TITLE
Complete Task 12.3 - Create useRole Custom Hook

### DIFF
--- a/app/test-use-role/page.tsx
+++ b/app/test-use-role/page.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useRole } from '@/hooks'
+
+export default function TestUseRolePage() {
+  const { role, isLoading, isAdmin, isUser } = useRole()
+
+  if (isLoading) {
+    return (
+      <div className="p-8">
+        <h1 className="mb-4 text-2xl font-bold">Testing useRole Hook</h1>
+        <p>Loading user role...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="mb-4 text-2xl font-bold">Testing useRole Hook</h1>
+      <div className="space-y-2">
+        <p>
+          <strong>Role:</strong> {role || 'No role assigned'}
+        </p>
+        <p>
+          <strong>Is Loading:</strong> {isLoading.toString()}
+        </p>
+        <p>
+          <strong>Is Admin:</strong> {isAdmin.toString()}
+        </p>
+        <p>
+          <strong>Is User:</strong> {isUser.toString()}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -7,3 +7,4 @@ export {
   useAnalysisVoteStats,
   useSortedAnalyses,
 } from './use-vote-analytics'
+export { useRole, type UserRole } from './useRole'

--- a/hooks/useRole.ts
+++ b/hooks/useRole.ts
@@ -1,0 +1,22 @@
+import { useUser } from '@clerk/nextjs'
+
+export type UserRole = 'admin' | 'user' | 'guest' | 'member' | null
+
+export function useRole(): {
+  role: UserRole
+  isLoading: boolean
+  isAdmin: boolean
+  isUser: boolean
+} {
+  const { user, isLoaded } = useUser()
+
+  // Extract role from Clerk user's publicMetadata
+  const role = (user?.publicMetadata?.role as UserRole) || null
+
+  return {
+    role,
+    isLoading: !isLoaded,
+    isAdmin: role === 'admin',
+    isUser: role === 'user',
+  }
+}


### PR DESCRIPTION
## Summary
- ✅ Implemented `useRole` custom hook in `hooks/useRole.ts`
- ✅ Hook fetches user role from Clerk `publicMetadata.role`
- ✅ Returns role, loading state, and convenience booleans (`isAdmin`, `isUser`)
- ✅ Handles loading and unauthenticated states properly
- ✅ Added TypeScript types and exported from hooks index
- ✅ Created test page for verification

## Test Plan
- [x] Hook correctly extracts role from Clerk user metadata
- [x] Returns proper loading states
- [x] Handles null/undefined cases for unauthenticated users
- [x] TypeScript compilation passes
- [x] Exports work correctly from hooks/index.ts

## Implementation Details
The `useRole` hook uses Clerk's `useUser` hook to access `user.publicMetadata.role` and provides a clean interface for role-based access control throughout the application.

Ready to merge into feature/role-based-access

🤖 Generated with [Claude Code](https://claude.ai/code)