### PR TITLE
Complete Task 12.4 - Conditionally Render Admin UI and Navigation

### DIFF
--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { useRole } from '@/hooks/useRole'
 
 interface HeaderProps {
   title?: string
@@ -25,6 +26,7 @@ interface HeaderProps {
 export function Header({ title = 'Akarii' }: HeaderProps) {
   const { isSignedIn } = useAuth()
   const { user } = useUser()
+  const { isAdmin } = useRole()
 
   return (
     <header className="border-b bg-background px-6 py-4">
@@ -43,32 +45,41 @@ export function Header({ title = 'Akarii' }: HeaderProps) {
                 </Link>
               </Button>
 
-              <Button variant="ghost" size="sm" asChild>
-                <Link href="/dashboard" className="flex items-center space-x-2">
-                  <Users className="h-4 w-4" />
-                  <span>Teams</span>
-                </Link>
-              </Button>
+              {isAdmin && (
+                <Button variant="ghost" size="sm" asChild>
+                  <Link
+                    href="/dashboard"
+                    className="flex items-center space-x-2"
+                  >
+                    <Users className="h-4 w-4" />
+                    <span>Teams</span>
+                  </Link>
+                </Button>
+              )}
 
-              <Button variant="ghost" size="sm" asChild>
-                <Link
-                  href="/experiments"
-                  className="flex items-center space-x-2"
-                >
-                  <BarChart3 className="h-4 w-4" />
-                  <span>Experiments</span>
-                </Link>
-              </Button>
+              {isAdmin && (
+                <Button variant="ghost" size="sm" asChild>
+                  <Link
+                    href="/experiments"
+                    className="flex items-center space-x-2"
+                  >
+                    <BarChart3 className="h-4 w-4" />
+                    <span>Experiments</span>
+                  </Link>
+                </Button>
+              )}
 
-              <Button variant="ghost" size="sm" asChild>
-                <Link
-                  href="/cost-dashboard"
-                  className="flex items-center space-x-2"
-                >
-                  <Settings className="h-4 w-4" />
-                  <span>Analytics</span>
-                </Link>
-              </Button>
+              {isAdmin && (
+                <Button variant="ghost" size="sm" asChild>
+                  <Link
+                    href="/cost-dashboard"
+                    className="flex items-center space-x-2"
+                  >
+                    <Settings className="h-4 w-4" />
+                    <span>Analytics</span>
+                  </Link>
+                </Button>
+              )}
             </nav>
           )}
         </div>


### PR DESCRIPTION
## Summary
- ✅ Added conditional rendering for admin navigation links using useRole hook
- ✅ Teams, Experiments, and Analytics links now only display for admin users
- ✅ Implemented proper role-based access control in the header component
- ✅ Maintains clean UI by hiding admin features from regular users

## Implementation Details
- Import and use `useRole` hook in header component
- Wrap admin navigation links (Teams, Experiments, Analytics) in `{isAdmin && ...}` conditional blocks
- Preserves existing functionality while adding role-based visibility

## Test Plan
- [x] Development server starts successfully
- [x] Code passes formatting checks
- [x] Admin navigation links properly wrapped in conditional rendering
- [x] useRole hook integration works correctly

Ready to merge into feature/role-based-access

🤖 Generated with [Claude Code](https://claude.ai/code)