### PR TITLE
Hide debug panel from non-admin users on home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,11 +7,13 @@ import { PrismPanel } from '@/components/analysis'
 import { ScrollSyncProvider } from '@/contexts/scroll-sync-context'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { useRole } from '@/hooks/useRole'
 import Link from 'next/link'
 
 export default function Home() {
   const { isSignedIn, isLoaded } = useAuth()
   const { user } = useUser()
+  const { role, isLoading: roleLoading } = useRole()
 
   // Demo conversation ID - in production this would come from routing or user selection
   const demoConversationId = 'demo-conversation-123'
@@ -41,11 +43,11 @@ export default function Home() {
             AI-powered real-time message analysis platform
           </p>
 
-          {/* Debug: Show user role information */}
-          {isSignedIn && user && (
+          {/* Debug: Show user role information - Admin only */}
+          {isSignedIn && user && role === 'admin' && (
             <div className="rounded-lg border bg-card p-4 text-left text-sm">
               <h3 className="mb-2 font-semibold">
-                Debug: User Role Information
+                Debug: User Role Information (Admin Only)
               </h3>
               <div className="space-y-1 font-mono">
                 <div>Email: {user.primaryEmailAddress?.emailAddress}</div>


### PR DESCRIPTION
## Summary
- ✅ Debug panel now only visible to admin users
- ✅ Improved security by hiding sensitive user metadata
- ✅ Better UX for regular users (cleaner home page)

## Changes
- Added `useRole` hook import to home page
- Modified debug panel condition to check `role === 'admin'`
- Updated panel title to indicate admin-only visibility
- Maintains functionality for admin users while hiding from others

## Security Improvement
The debug panel previously showed sensitive user information including:
- User email addresses
- Internal user IDs
- Complete publicMetadata content
- Role information

This information is now only visible to admin users, improving both security and UX.

## Testing
- [x] Admin users can still see the debug panel
- [x] Non-admin users no longer see sensitive information
- [x] Home page functionality preserved for all users
- [x] Application builds and runs successfully

Ready to merge into feature/role-based-access

🤖 Generated with [Claude Code](https://claude.ai/code)